### PR TITLE
マトリックスビルドによるUbuntu/Alpine版イメージの並行作成

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -200,8 +200,8 @@ jobs:
           run: |
             set -x
             docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64-${{ matrix.tag_dist }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64-${{ matrix.tag_dist }}
+              ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-amd64 \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-arm64
               docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}
 
     create-latest:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -100,22 +100,22 @@ jobs:
             include:
               - platform: linux/amd64
                 runner: ubuntu-24.04
-                tag_suffix: amd64
+                tag_arch: amd64
                 dockerfile: Dockerfile
                 tag_dist: "ubuntu"
               - platform: linux/amd64
                 runner: ubuntu-24.04
-                tag_suffix: amd64
+                tag_arch: amd64
                 dockerfile: Dockerfile.alpine
                 tag_dist: "alpine"
               - platform: linux/arm64
                 runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-                tag_suffix: arm64
+                tag_arch: arm64
                 dockerfile: Dockerfile
                 tag_dist: "ubuntu"
               - platform: linux/arm64
                 runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
-                tag_suffix: arm64
+                tag_arch: arm64
                 dockerfile: Dockerfile.alpine
                 tag_dist: "alpine"
         runs-on: ${{ matrix.runner }}
@@ -133,7 +133,7 @@ jobs:
             # 各マトリックスの値も出力
             echo "matrix.platform=${{ matrix.platform }}"
             echo "matrix.runner=${{ matrix.runner }}"
-            echo "matrix.tag_suffix=${{ matrix.tag_suffix }}"
+            echo "matrix.tag_arch=${{ matrix.tag_arch }}"
             echo "matrix.dockerfile=${{ matrix.dockerfile }}"
         - name: 変数BRANCH_NAMEの値を出力
           run: echo $BRANCH_NAME
@@ -159,11 +159,11 @@ jobs:
             push: ${{ needs.check-act.outputs.IS_ACT != 'true' }}
             load: true
             provenance: false
-            tags: ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_suffix }}-${{ matrix.tag_dist }},${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_dist }}-${{ matrix.tag_suffix }}
+            tags: ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-${{ matrix.tag_arch }},${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_dist }}-${{ matrix.tag_arch }}
         - name: "(act上)イメージの削除"
           if: needs.check-act.outputs.IS_ACT == 'true'
           run: |
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-${{ matrix.tag_suffix }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-${{ matrix.tag_arch }} || true
     
     # マニフェストを作成して両アーキテクチャを統合利用(actでは実行しない)
     create-manifest:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -167,6 +167,7 @@ jobs:
     
     # マニフェストを作成して両アーキテクチャを統合利用(actでは実行しない)
     create-manifest:
+      id: create-manifest
       runs-on: ubuntu-24.04
       timeout-minutes: 1
       strategy:
@@ -203,6 +204,7 @@ jobs:
               ${{ needs.make-imagename.outputs.image_name_tag }}-amd64-${{ matrix.tag_dist }} \
               ${{ needs.make-imagename.outputs.image_name_tag }}-arm64-${{ matrix.tag_dist }}
               docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}
+
     create-latest:
       # mainブランチのときのみ、latestタグを作成する、latestタグはubuntu側を指すようにしておく
       runs-on: ubuntu-24.04
@@ -210,6 +212,7 @@ jobs:
         - build
         - check-act
         - make-imagename
+        - create-manifest
       if: needs.check-act.outputs.IS_ACT != 'true' && github.ref == 'refs/heads/main'
       steps:
         - name: GHCRにログイン

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -107,12 +107,12 @@ jobs:
                 dockerfile: Dockerfile.alpine
                 tag_dist: "alpine"
               - platform: linux/arm64
-                runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+                runner: ${{ needs.check-act.outputs.RUNNER }}
                 tag_arch: arm64
                 dockerfile: Dockerfile
                 tag_dist: "ubuntu"
               - platform: linux/arm64
-                runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+                runner: ${{ needs.check-act.outputs.RUNNER }}
                 tag_arch: arm64
                 dockerfile: Dockerfile.alpine
                 tag_dist: "alpine"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -226,8 +226,9 @@ jobs:
           run: |
             set -x
             docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-ubuntu
-              docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}
+              ${{ needs.make-imagename.outputs.image_name_tag }}-ubuntu-amd64 \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-ubuntu-arm64
+            docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}
 
     create-latest:
       # mainブランチのときのみ、latestタグを作成する、latestタグはubuntu側を指すようにしておく
@@ -248,9 +249,15 @@ jobs:
 
         - name: latestタグの作成
           run: |
-            docker tag ${{ needs.make-imagename.outputs.image_name_latest }}-ubuntu \
-              ${{ needs.make-imagename.outputs.image_name_latest }}
-            docker push ${{ needs.make-imagename.outputs.image_name_latest }}
+            docker manifest create ${{ needs.make-imagename.outputs.image_name_latest }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-ubuntu-amd64 \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-ubuntu-arm64
+            docker manifest push ${{ needs.make-imagename.outputs.image_name_latest }}
+
+            # docker image pull ${{ needs.make-imagename.outputs.image_name_latest }}-ubuntu
+            # docker tag ${{ needs.make-imagename.outputs.image_name_latest }}-ubuntu \
+            #   ${{ needs.make-imagename.outputs.image_name_latest }}
+            # docker push ${{ needs.make-imagename.outputs.image_name_latest }}
 
     # act環境の際、残ってるイメージデータなどを削除しておく
     cleanup:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -8,8 +8,6 @@ name: Docker Image CI
 
 on:
     push:
-        # branches:
-        #   - main
     workflow_dispatch: # 手動実行
 
 # GHCRへのプッシュにはパーミッションが必要です
@@ -241,15 +239,15 @@ jobs:
         fail-fast: true
         matrix:
           dist:
-            - ""
-            - "-alpine"
+            - "ubuntu"
+            - "alpine"
       steps:
         - name: act環境のイメージ削除
           run: |
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-amd64${{ matrix.dist }} || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-arm64${{ matrix.dist }} || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_latest }}${{ matrix.dist }} || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}${{ matrix.dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.dist }}-amd64 || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.dist }}-arm64 || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.dist }} || true
             docker image prune -f
 
     update-template-repo:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -238,16 +238,16 @@ jobs:
       strategy:
         fail-fast: true
         matrix:
-          dist:
+          tag_dist:
             - "ubuntu"
             - "alpine"
       steps:
         - name: act環境のイメージ削除
           run: |
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.dist }}-amd64 || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.dist }}-arm64 || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.dist }} || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-amd64 || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-arm64 || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }} || true
             docker image prune -f
 
     update-template-repo:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -129,6 +129,7 @@ jobs:
             fi
             echo "EPOCH_TIME=$(date +%s)" >> $GITHUB_ENV
         - name: "デバッグ用: 環境変数の出力"
+          if: ${{ github.event_name == 'workflow_dispatch' || github.ref != 'refs/heads/main' }}
           run: |
             # 各マトリックスの値も出力
             echo "matrix.platform=${{ matrix.platform }}"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -102,22 +102,22 @@ jobs:
                 runner: ubuntu-24.04
                 tag_suffix: amd64
                 dockerfile: build/Dockerfile
-                tag_dist: ""
+                tag_dist: "ubuntu"
               - platform: linux/amd64
                 runner: ubuntu-24.04
                 tag_suffix: amd64
                 dockerfile: Dockerfile.alpine
-                tag_dist: -alpine
+                tag_dist: "alpine"
               - platform: linux/arm64
-                runner: ubuntu-24.04-arm
+                runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
                 tag_suffix: arm64
                 dockerfile: build/Dockerfile
-                tag_dist: ""
+                tag_dist: "ubuntu"
               - platform: linux/arm64
-                runner: ubuntu-24.04-arm
+                runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
                 tag_suffix: arm64
                 dockerfile: Dockerfile.alpine
-                tag_dist: -alpine
+                tag_dist: "alpine"
         runs-on: ${{ matrix.runner }}
         steps:
         - name: ブランチ名を取得して環境変数にセット
@@ -128,6 +128,13 @@ jobs:
               echo "BRANCH_NAME=latest" >> $GITHUB_ENV
             fi
             echo "EPOCH_TIME=$(date +%s)" >> $GITHUB_ENV
+        - name: "デバッグ用: 環境変数の出力"
+          run: |
+            # 各マトリックスの値も出力
+            echo "matrix.platform=${{ matrix.platform }}"
+            echo "matrix.runner=${{ matrix.runner }}"
+            echo "matrix.tag_suffix=${{ matrix.tag_suffix }}"
+            echo "matrix.dockerfile=${{ matrix.dockerfile }}"
         - name: 変数BRANCH_NAMEの値を出力
           run: echo $BRANCH_NAME
         - name: チェックアウト
@@ -147,16 +154,16 @@ jobs:
           uses: docker/build-push-action@v5
           with:
             context: .
-            file: ./build/Dockerfile
+            file: ./build/${{ matrix.dockerfile }}
             platforms: ${{ matrix.platform }}
             push: ${{ needs.check-act.outputs.IS_ACT != 'true' }}
             load: true
             provenance: false
-            tags: ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_suffix }}-${{ matrix.tag_dist }},${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_suffix }}${{ matrix.tag_dist }}
+            tags: ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_suffix }}-${{ matrix.tag_dist }},${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_dist }}-${{ matrix.tag_suffix }}
         - name: "(act上)イメージの削除"
           if: needs.check-act.outputs.IS_ACT == 'true'
           run: |
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_suffix }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-${{ matrix.tag_suffix }} || true
     
     # マニフェストを作成して両アーキテクチャを統合利用(actでは実行しない)
     create-manifest:
@@ -165,9 +172,9 @@ jobs:
       strategy:
         fail-fast: true
         matrix:
-          dist:
-            - ""
-            - "-alpine"
+          tag_dist:
+            - "ubuntu"
+            - "alpine"
       needs:
         - build
         - check-act
@@ -184,20 +191,40 @@ jobs:
 
         - name: マニフェストの作成(latest) -> プッシュ
           # このステップ自体をmainブランチのときはスキップする
-          if: github.ref == 'refs/heads/main'
           run: |
-            docker manifest create ${{ needs.make-imagename.outputs.image_name_latest }}${{ matrix.tag_dist }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64${{ matrix.tag_dist }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64${{ matrix.tag_dist }}
-            docker manifest push ${{ needs.make-imagename.outputs.image_name_latest }}${{ matrix.tag_dist }}
+            docker manifest create ${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-amd64 \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-arm64
+            docker manifest push ${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_dist }}
         - name: マニフェストの作成(シリアル値) → プッシュ
           run: |
             set -x
-            docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }}${{ matrix.tag_dist }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64${{ matrix.tag_dist }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64${{ matrix.tag_dist }}
-              docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}${{ matrix.tag_dist }}
-  
+            docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64-${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64-${{ matrix.tag_dist }}
+              docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}
+    create-latest:
+      # mainブランチのときのみ、latestタグを作成する、latestタグはubuntu側を指すようにしておく
+      runs-on: ubuntu-24.04
+      needs:
+        - build
+        - check-act
+        - make-imagename
+      if: needs.check-act.outputs.IS_ACT != 'true' && github.ref == 'refs/heads/main'
+      steps:
+        - name: GHCRにログイン
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: latestタグの作成
+          run: |
+            docker tag ${{ needs.make-imagename.outputs.image_name_latest }}-ubuntu \
+              ${{ needs.make-imagename.outputs.image_name_latest }}
+            docker push ${{ needs.make-imagename.outputs.image_name_latest }}
+
     # act環境の際、残ってるイメージデータなどを削除しておく
     cleanup:
       runs-on: ubuntu-24.04

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -101,7 +101,7 @@ jobs:
               - platform: linux/amd64
                 runner: ubuntu-24.04
                 tag_suffix: amd64
-                dockerfile: build/Dockerfile
+                dockerfile: Dockerfile
                 tag_dist: "ubuntu"
               - platform: linux/amd64
                 runner: ubuntu-24.04
@@ -111,7 +111,7 @@ jobs:
               - platform: linux/arm64
                 runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
                 tag_suffix: arm64
-                dockerfile: build/Dockerfile
+                dockerfile: Dockerfile
                 tag_dist: "ubuntu"
               - platform: linux/arm64
                 runner: ${{ needs.check-act.outputs.IS_ACT == 'true' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -203,6 +203,32 @@ jobs:
               ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}-arm64
               docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_dist }}
 
+
+    # メインのマニフェストを作成(現在はubuntu)
+    create-main:
+      runs-on: ubuntu-24.04
+      timeout-minutes: 1
+      needs:
+        - build
+        - check-act
+        - make-serial
+        - make-imagename
+        - create-manifest
+      steps:
+        - name: GHCRにログイン
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: マニフェストの作成(シリアル値) → プッシュ
+          run: |
+            set -x
+            docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-ubuntu
+              docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}
+
     create-latest:
       # mainブランチのときのみ、latestタグを作成する、latestタグはubuntu側を指すようにしておく
       runs-on: ubuntu-24.04

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -211,7 +211,7 @@ jobs:
         - check-act
         - make-imagename
         - create-manifest
-      if: needs.check-act.outputs.IS_ACT != 'true' && github.ref == 'refs/heads/main'
+      if: needs.check-act.outputs.IS_ACT != 'true'
       steps:
         - name: GHCRにログイン
           uses: docker/login-action@v3

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -8,8 +8,8 @@ name: Docker Image CI
 
 on:
     push:
-        branches:
-          - main
+        # branches:
+        #   - main
     workflow_dispatch: # 手動実行
 
 # GHCRへのプッシュにはパーミッションが必要です
@@ -101,10 +101,23 @@ jobs:
               - platform: linux/amd64
                 runner: ubuntu-24.04
                 tag_suffix: amd64
+                dockerfile: build/Dockerfile
+                tag_dist: ""
+              - platform: linux/amd64
+                runner: ubuntu-24.04
+                tag_suffix: amd64
+                dockerfile: Dockerfile.alpine
+                tag_dist: -alpine
               - platform: linux/arm64
-                runner: ${{ needs.check-act.outputs.RUNNER }}
+                runner: ubuntu-24.04-arm
                 tag_suffix: arm64
-
+                dockerfile: build/Dockerfile
+                tag_dist: ""
+              - platform: linux/arm64
+                runner: ubuntu-24.04-arm
+                tag_suffix: arm64
+                dockerfile: Dockerfile.alpine
+                tag_dist: -alpine
         runs-on: ${{ matrix.runner }}
         steps:
         - name: ブランチ名を取得して環境変数にセット
@@ -139,7 +152,7 @@ jobs:
             push: ${{ needs.check-act.outputs.IS_ACT != 'true' }}
             load: true
             provenance: false
-            tags: ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_suffix }}
+            tags: ${{ needs.make-imagename.outputs.image_name_tag }}-${{ matrix.tag_suffix }}-${{ matrix.tag_dist }},${{ needs.make-imagename.outputs.image_name_latest }}-${{ matrix.tag_suffix }}${{ matrix.tag_dist }}
         - name: "(act上)イメージの削除"
           if: needs.check-act.outputs.IS_ACT == 'true'
           run: |
@@ -149,6 +162,12 @@ jobs:
     create-manifest:
       runs-on: ubuntu-24.04
       timeout-minutes: 1
+      strategy:
+        fail-fast: true
+        matrix:
+          dist:
+            - ""
+            - "-alpine"
       needs:
         - build
         - check-act
@@ -163,23 +182,22 @@ jobs:
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: マニフェストの作成(latest)
+        - name: マニフェストの作成(latest) -> プッシュ
+          # このステップ自体をmainブランチのときはスキップする
+          if: github.ref == 'refs/heads/main'
+          run: |
+            docker manifest create ${{ needs.make-imagename.outputs.image_name_latest }}${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64${{ matrix.tag_dist }}
+            docker manifest push ${{ needs.make-imagename.outputs.image_name_latest }}${{ matrix.tag_dist }}
+        - name: マニフェストの作成(シリアル値) → プッシュ
           run: |
             set -x
-            docker manifest create ${{ needs.make-imagename.outputs.image_name_latest }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64 \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64
-        - name: マニフェストの作成(シリアル値)
-          run: |
-            set -x
-            docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }} \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64 \
-              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64
-        - name: マニフェストのプッシュ
-          run: |
-            docker manifest push ${{ needs.make-imagename.outputs.image_name_latest }}
-            docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}
-
+            docker manifest create ${{ needs.make-imagename.outputs.image_name_tag }}${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-amd64${{ matrix.tag_dist }} \
+              ${{ needs.make-imagename.outputs.image_name_tag }}-arm64${{ matrix.tag_dist }}
+              docker manifest push ${{ needs.make-imagename.outputs.image_name_tag }}${{ matrix.tag_dist }}
+  
     # act環境の際、残ってるイメージデータなどを削除しておく
     cleanup:
       runs-on: ubuntu-24.04
@@ -189,13 +207,19 @@ jobs:
         - make-imagename
         - check-act
       if: needs.check-act.outputs.IS_ACT == 'true'
+      strategy:
+        fail-fast: true
+        matrix:
+          dist:
+            - ""
+            - "-alpine"
       steps:
         - name: act環境のイメージ削除
           run: |
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-amd64 || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-arm64 || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_latest }} || true
-            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-amd64${{ matrix.dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}-arm64${{ matrix.dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_latest }}${{ matrix.dist }} || true
+            docker rmi ${{ needs.make-imagename.outputs.image_name_tag }}${{ matrix.dist }} || true
             docker image prune -f
 
     update-template-repo:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -167,7 +167,6 @@ jobs:
     
     # マニフェストを作成して両アーキテクチャを統合利用(actでは実行しない)
     create-manifest:
-      id: create-manifest
       runs-on: ubuntu-24.04
       timeout-minutes: 1
       strategy:


### PR DESCRIPTION
UbuntuとAlpine、それぞれをベースとしたイメージの作成を行えるようにしました。
現状ではUbuntu版をメインとしてlatestに紐付けるようにしています。

同時に #7 の問題も解決しています。