### PR TITLE
Ubuntu版とAlpine版のビルドの基準ディレクトリを揃えたい

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -98,7 +98,7 @@ jobs:
         - name: "イメージのビルド"
           uses: docker/build-push-action@v5
           with:
-            context: ./build
+            context: .
             file: ./build/Dockerfile.alpine
             platforms: ${{ matrix.platform }}
             # あくまでビルドのテスト用です、よってイメージのプッシュは行いません


### PR DESCRIPTION
テストビルドを作成する際に、ubuntu版とalpine版でイメージの作成の際の基準ディレクトリが
異なるということが判明しました。
他のワークフロー(簡易テストと本番イメージ作成)は基準が同じトップディレクトリでしたが、
テストビルドだけずれていました。

揃えることでテストなどで影響が少なくなることを狙ったコミットとなります。
ついでにワークフローが並列で発火したときのキャンセル方法も改善を狙って参照する値を変更しています。
